### PR TITLE
Don't build zypak

### DIFF
--- a/com.axosoft.GitKraken.json
+++ b/com.axosoft.GitKraken.json
@@ -28,17 +28,6 @@
     ],
     "modules": [
         {
-            "name": "zypak",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/refi64/zypak",
-                    "tag": "v2019.11beta.3",
-                    "commit": "8aff41c45ee648f718f64a5fd6346f9b0220946c"
-                }
-            ]
-        },
-        {
             "name": "ar",
             "buildsystem": "simple",
             "build-commands": [


### PR DESCRIPTION
It's now bundled inside org.electronjs.Electron2.BaseApp