### PR TITLE
use bsdtar instead of ar to extract the binary deb

### DIFF
--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -2,8 +2,13 @@
 
 set -e
 
-ar p gitkraken.deb data.tar.xz | tar -xJf -
+bsdtar -Oxf gitkraken.deb 'data.tar.*' |
+  bsdtar -xf - \
+    --strip-components=3 \
+    --exclude='./usr/bin/' \
+    --exclude='./usr/share/applications/' \
+    --exclude='./usr/share/doc/' \
+    --exclude='./usr/share/lintian/' \
+    --exclude='./usr/share/pixmaps/'
 
-mv usr/share/gitkraken gitkraken
-
-rm -rf gitkraken.deb usr
+rm -rf gitkraken.deb

--- a/com.axosoft.GitKraken.json
+++ b/com.axosoft.GitKraken.json
@@ -103,14 +103,6 @@
             ]
         },
         {
-            "name": "ar",
-            "buildsystem": "simple",
-            "build-commands": [
-                "install -Dm0755 /usr/lib/$(gcc -print-multiarch)/libbfd-*.so -t ${FLATPAK_DEST}/lib/",
-                "install -Dm0755 $(which ar) ${FLATPAK_DEST}/bin/"
-            ]
-        },
-        {
             "name": "git",
             "buildsystem": "simple",
             "build-commands": [

--- a/gitkraken-build.sh
+++ b/gitkraken-build.sh
@@ -2,21 +2,27 @@
 
 set -eux
 
-install -Dm0755 apply_extra.sh ${FLATPAK_DEST}/bin/apply_extra
-install -Dm0755 gitkraken.sh ${FLATPAK_DEST}/bin/gitkraken
-install -Dm0644 ${FLATPAK_ID}.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
+install -Dm0755 apply_extra.sh "${FLATPAK_DEST}/bin/apply_extra"
+install -Dm0755 gitkraken.sh "${FLATPAK_DEST}/bin/gitkraken"
+install -Dm0644 "${FLATPAK_ID}.metainfo.xml" "${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml"
 
-ar p gitkraken.deb data.tar.xz | tar -xJf -
+bsdtar -Oxf gitkraken.deb 'data.tar.*' |
+  bsdtar -xf - \
+    --strip-components=3 \
+    --exclude='./usr/bin/' \
+    --exclude='./usr/share/doc/' \
+    --exclude='./usr/share/gitkraken/' \
+    --exclude='./usr/share/lintian/' \
 
-install -Dm0644 usr/share/applications/gitkraken.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
-desktop-file-edit --set-key="Exec" --set-value="gitkraken %U" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
-desktop-file-edit --set-key="Icon" --set-value=${FLATPAK_ID} ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
+install -Dm0644 applications/gitkraken.desktop "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
+desktop-file-edit --set-key="Exec" --set-value="gitkraken %U" "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
+desktop-file-edit --set-key="Icon" --set-value="${FLATPAK_ID}" "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
 
-install -Dm0644 usr/share/applications/gitkraken-url-handler.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.UrlHandler.desktop
-desktop-file-edit --set-key="Exec" --set-value="gitkraken --uri %U" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.UrlHandler.desktop
-desktop-file-edit --set-key="Icon" --set-value=${FLATPAK_ID} ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.UrlHandler.desktop
+install -Dm0644 applications/gitkraken-url-handler.desktop "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.UrlHandler.desktop"
+desktop-file-edit --set-key="Exec" --set-value="gitkraken --uri %U" "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.UrlHandler.desktop"
+desktop-file-edit --set-key="Icon" --set-value="${FLATPAK_ID}" "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.UrlHandler.desktop"
 
 for size in 64 128 264 512; do
-    convert usr/share/gitkraken/gitkraken.png -resize ${size} ${FLATPAK_ID}.png
-    install -Dm0644 ${FLATPAK_ID}.png ${FLATPAK_DEST}/share/icons/hicolor/${size}x${size}/apps/${FLATPAK_ID}.png
+    convert pixmaps/gitkraken.png -resize "${size}" "${FLATPAK_ID}.png"
+    install -Dm0644 "${FLATPAK_ID}.png" "${FLATPAK_DEST}/share/icons/hicolor/${size}x${size}/apps/${FLATPAK_ID}.png"
 done

--- a/gitkraken.sh
+++ b/gitkraken.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-exec env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/extra/gitkraken/gitkraken "$@"
+exec env TMPDIR="$XDG_CACHE_HOME" zypak-wrapper /app/extra/gitkraken/gitkraken "$@"


### PR DESCRIPTION
- bsdtar is already present in the Runtime
- extract only what's needed
- use a wildcard so the extraction won't fail if the chosen compression type changed