### PR TITLE
Adding support for Wayland.

### DIFF
--- a/com.axosoft.GitKraken.json
+++ b/com.axosoft.GitKraken.json
@@ -14,6 +14,8 @@
         "--require-version=0.11.1",
         "--share=ipc",
         "--socket=x11",
+        "--socket=fallback-x11",
+        "--socket=wayland",
         "--socket=pulseaudio",
         "--socket=ssh-auth",
         "--socket=pcsc",


### PR DESCRIPTION
When in a Wayland desktop session, the integrations with GitHub and others doesn't work without adding the Wayland Windows Systems permission. I have added the Wayland and fallback x11 sockets to enable it to work by default.