### PR TITLE
Include suggestions message

### DIFF
--- a/gitkraken.sh
+++ b/gitkraken.sh
@@ -2,4 +2,11 @@
 
 set -e
 
+FLAG_FILE="$XDG_CONFIG_HOME/.zenity_please_ask_for_support"
+
+if [ ! -f "$FLAG_FILE" ]; then
+    zenity --info --text='Please, ask Axosoft to officially support Flatpak. With recent upstream changes, this package has become far less reliable. \n\n <a href="https://feedback.gitkraken.com/suggestions/308722/flatpak-installer-on-flathub">Gitkraken Suggestions</a>'
+    touch "$FLAG_FILE"
+fi
+
 exec env TMPDIR="$XDG_CACHE_HOME" zypak-wrapper /app/extra/gitkraken/gitkraken "$@"


### PR DESCRIPTION
@Lctrs With GitKraken changing their URL, they're making our job worse.

Since I have a pro account, I figured I would write them. They told me that they have no plans in officially supporting Flatpak and they've pointed me towards this suggestion:

https://feedback.gitkraken.com/suggestions/308722/flatpak-installer-on-flathub

Since it only has 22 votes... and this Flatpak has 150.000+ installations, I think it would be a good idea to ask the current installation base to bugger Axosoft. I will not renew my license when it runs out, so after that I won't be able (or willing) to update this application when things go bad.