### PR TITLE
Add GitKraken CLI extension

### DIFF
--- a/com.axosoft.GitKraken.json
+++ b/com.axosoft.GitKraken.json
@@ -10,6 +10,15 @@
         "proprietary"
     ],
     "separate-locales": false,
+    "add-extensions": {
+        "com.axosoft.GitKraken.plugin": {
+            "directory": "plugin",
+            "subdirectories": true,
+            "merge-dirs": "bin",
+            "no-autodownload": true,
+            "autodelete": true
+        }
+    },
     "finish-args": [
         "--require-version=0.11.1",
         "--share=ipc",
@@ -225,6 +234,26 @@
                         "version-pattern": "Latest release: ((?:\\d+\\.)?(?:\\d+\\.)?\\d+)",
                         "url-template": "https://api.gitkraken.dev/releases/production/linux/x64/$version/gitkraken-amd64.deb",
                         "is-main-source": true
+                    }
+                }
+            ]
+        },
+        {
+            "name": "gk",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -Dm755 gk ${FLATPAK_DEST}/plugin/gk/bin/gk"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/gitkraken/gk-cli/releases/download/v3.1.40/gk_3.1.40_linux_amd64.zip",
+                    "sha256": "7b0f87f204f1e2986bdc8ff8106031f3df23a01e2ae41cf38bf06ab12b2dd5e5",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/gitkraken/gk-cli/releases/latest",
+                        "version-query": ".tag_name | sub(\"^v\"; \"\")",
+                        "url-query": ".assets[] | select(.name==\"gk_\" + $version + \"_linux_amd64.zip\") | .browser_download_url"
                     }
                 }
             ]

--- a/com.axosoft.GitKraken.json
+++ b/com.axosoft.GitKraken.json
@@ -11,12 +11,11 @@
     ],
     "separate-locales": false,
     "add-extensions": {
-        "com.axosoft.GitKraken.plugin": {
-            "directory": "plugin",
-            "subdirectories": true,
-            "merge-dirs": "bin",
+        "com.axosoft.GitKraken.plugin.gk": {
+            "directory": "plugin/gk",
             "no-autodownload": true,
-            "autodelete": true
+            "autodelete": true,
+            "bundle": true
         }
     },
     "finish-args": [

--- a/gitkraken-build.sh
+++ b/gitkraken-build.sh
@@ -26,3 +26,5 @@ for size in 64 128 264 512; do
     convert pixmaps/gitkraken.png -resize "${size}" "${FLATPAK_ID}.png"
     install -Dm0644 "${FLATPAK_ID}.png" "${FLATPAK_DEST}/share/icons/hicolor/${size}x${size}/apps/${FLATPAK_ID}.png"
 done
+
+mkdir -p "${FLATPAK_DEST}/plugin/bin"

--- a/gitkraken.sh
+++ b/gitkraken.sh
@@ -9,4 +9,4 @@ if [ ! -f "$FLAG_FILE" ]; then
     touch "$FLAG_FILE"
 fi
 
-exec env TMPDIR="$XDG_CACHE_HOME" zypak-wrapper /app/extra/gitkraken/gitkraken "$@"
+exec env TMPDIR="$XDG_CACHE_HOME" PATH="$PATH:/app/plugin/bin" zypak-wrapper /app/extra/gitkraken/gitkraken "$@"

--- a/gitkraken.sh
+++ b/gitkraken.sh
@@ -9,4 +9,4 @@ if [ ! -f "$FLAG_FILE" ]; then
     touch "$FLAG_FILE"
 fi
 
-exec env TMPDIR="$XDG_CACHE_HOME" PATH="$PATH:/app/plugin/bin" zypak-wrapper /app/extra/gitkraken/gitkraken "$@"
+exec env TMPDIR="$XDG_CACHE_HOME" PATH="$PATH:/app/plugin/gk/bin" zypak-wrapper /app/extra/gitkraken/gitkraken "$@"


### PR DESCRIPTION
This PR builds the GitKraken CLI as an extension to the GitKraken flatpak. Users can optionally install it by running

```
flatpak install com.axosoft.GitKraken.plugin.gk
```
after installing the `com.axosoft.GitKraken` flatpak.

Once installed, the extension makes `gk` available in the terminal inside GitKraken desktop. Also, users can run the CLI outside of GitKraken desktop by running

```
flatpak run --command=/app/plugin/bin/gk com.axosoft.GitKraken <args to gk>
```

If you want the CLI to be installed by default when installing `com.axosoft.GitKraken`, we can change `no-autodownload` to `false` in the definition of the extension point.

Fixes #251 